### PR TITLE
Fix issue with missing scipy package

### DIFF
--- a/BlenderSpike/__init__.py
+++ b/BlenderSpike/__init__.py
@@ -18,8 +18,8 @@ def check_and_install_modules():
     '''
         Automatically install required Python modules
     '''
-    required_modules_import_names = ["matplotlib","seaborn", "cmasher", "numpy"]  # Required Python modules
-    required_modules_install_names = ["matplotlib","seaborn", "cmasher", "numpy"]
+    required_modules_import_names = ["matplotlib","seaborn", "cmasher", "numpy", "scipy"]  # Required Python modules
+    required_modules_install_names = ["matplotlib","seaborn", "cmasher", "numpy", "scipy"]
 
 
     missing_modules = []


### PR DESCRIPTION
Couldn't install the blender add-on due to this error message:

```
Traceback (most recent call last):
  File "/Applications/Blender.app/Contents/Resources/3.6/scripts/modules/addon_utils.py", line 333, in enable
    mod = __import__(module_name)
  File "Library/Application Support/Blender/3.6/scripts/addons/BlenderSpike/__init__.py", line 45, in <module>
    from .neuron_builder import NeuronBuilderProps, BLENDERSPIKE_OT_NeuronBuilder
  File "Library/Application Support/Blender/3.6/scripts/addons/BlenderSpike/neuron_builder.py", line 4, in <module>
    from .utils import linear_interpolation
  File "Library/Application Support/Blender/3.6/scripts/addons/BlenderSpike/utils.py", line 2, in <module>
    from scipy.interpolate import interp1d
ModuleNotFoundError: No module named 'scipy'
```